### PR TITLE
Update defaultTempo when tempo available

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -192,6 +192,7 @@ class Player {
 					if (dryRun && event) {
 						if (event.hasOwnProperty('name') && event.name === 'Set Tempo') {
 							// Grab tempo if available.
+							this.defaultTempo = event.data;
 							this.setTempo(event.data);
 						}
 						if (event.hasOwnProperty('name') && event.name === 'Program Change') {


### PR DESCRIPTION
Property defaultTempo is little useless right now, it's updated, and just stick all the time at 120 value.

It would be great if there was a possibility to back to "last" known tempo, after changing.