### PR TITLE
prevent endOfFile to overflow

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -421,7 +421,7 @@ class Player {
 	 */
 	endOfFile() {
 		if (this.isPlaying()) {
-			return this.eventsPlayed() == this.totalEvents;
+			return this.totalTicks - this.tick <= 0;
 		}
 
 		return this.bytesProcessed() == this.buffer.length;


### PR DESCRIPTION
Fix problem when playing not stops at the right moment. 

I have some wild playing sounds after progress going over 100%, moreover it should fix issue #32.

Right now Player.prototype.eventsPlayed is unused I would consider flagging it as depricated.
