### PR TITLE
Add rawEventCode key to eventJson

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -154,6 +154,7 @@ class Track	{
 		this.runningDelta += eventJson.delta;
 		eventJson.tick = this.runningDelta;
 		eventJson.byteIndex = this.pointer;
+		eventJson.rawEventCode = this.data[eventStartIndex];
 
 		//eventJson.raw = event;
 		if (this.data[eventStartIndex] == 0xff) {
@@ -163,6 +164,7 @@ class Track	{
 			// otherwise if we let it run through the next cycle a slight delay will accumulate if multiple tracks
 			// are being played simultaneously
 
+			eventJson.rawEventCode += this.data[eventStartIndex + 1];
 			switch(this.data[eventStartIndex + 1]) {
 				case 0x00: // Sequence Number
 					eventJson.name = 'Sequence Number';

--- a/src/track.js
+++ b/src/track.js
@@ -164,7 +164,7 @@ class Track	{
 			// otherwise if we let it run through the next cycle a slight delay will accumulate if multiple tracks
 			// are being played simultaneously
 
-			eventJson.rawEventCode += this.data[eventStartIndex + 1];
+			eventJson.rawEventCode = this.data[eventStartIndex + 1] << 8 + eventJson.rawEventCode;
 			switch(this.data[eventStartIndex + 1]) {
 				case 0x00: // Sequence Number
 					eventJson.name = 'Sequence Number';

--- a/src/track.js
+++ b/src/track.js
@@ -164,7 +164,7 @@ class Track	{
 			// otherwise if we let it run through the next cycle a slight delay will accumulate if multiple tracks
 			// are being played simultaneously
 
-			eventJson.rawEventCode = this.data[eventStartIndex + 1] << 8 + eventJson.rawEventCode;
+			eventJson.rawEventCode = (eventJson.rawEventCode << 8) + this.data[eventStartIndex + 1];
 			switch(this.data[eventStartIndex + 1]) {
 				case 0x00: // Sequence Number
 					eventJson.name = 'Sequence Number';


### PR DESCRIPTION
When i use player.play() and handle midi event. I need to handle 'Note on' and 'Note off' event only, and send them to [Jazz-midi](https://jazz-soft.net/) to play.
```javascript
if (event.name === 'Note on') {
  doSomething();
}
```
But it can't be played fluently if i use a complex MIDI file.
So i add 'rawEventCode' to 'eventJson', it's now can be played fluently.
```javascript
if (0x80 <= ev.rawEventCode && ev.rawEventCode <= 0x9f) {
  // Note on and Note off
  port.send(ev.rawEventCode, ev.noteNumber, ev.velocity);
} else if (0xc0 <= ev.rawEventCode && ev.rawEventCode <= 0xcf) {
   // Program Change
  port.send(ev.rawEventCode, ev.value);
 }
```