### PR TITLE
Fix black midi "lag" issue

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -192,6 +192,7 @@ class Player {
 	 * @return {undefined}
 	 */
 	playLoop(dryRun) {
+		var hadEvent = false;
 		if (!this.inLoop) {
 			this.inLoop = true;
 			this.tick = this.getCurrentTick();
@@ -204,6 +205,8 @@ class Player {
 					this.stop();
 				} else {
 					let event = track.handleEvent(this.tick, dryRun);
+					
+					if (event) hadEvent = true;
 
 					if (dryRun && event) {
 						if (event.hasOwnProperty('name') && event.name === 'Set Tempo') {
@@ -236,6 +239,7 @@ class Player {
 			if (!dryRun) this.triggerPlayerEvent('playing', {tick: this.tick});
 			this.inLoop = false;
 		}
+		return hadEvent;
 	}
 
 	/**
@@ -269,7 +273,9 @@ class Player {
 
 		// Start play loop
 		//window.requestAnimationFrame(this.playLoop.bind(this));
-		this.setIntervalId = setInterval(this.playLoop.bind(this), this.sampleRate);
+		this.setIntervalId = setInterval(() => {
+			while (this.playLoop()) {}
+		}, this.sampleRate);
 		//this.setIntervalId = this.loop();
 		return this;
 	}


### PR DESCRIPTION
In midi-player-js, there was an issue where only one event per track can play in each interval loop (by default every 5 milliseconds.) This would result in the player appearing to lag when a lot of notes are played at once, such as in black midis. This fix makes it continue to do a playLoop until it has fully caught up on events. This may not be the most efficient way to fix this issue, but it seems to fully fix it, as opposed to setting sampleRate to 0 which only makes the issue harder to see. https://github.com/grimmdude/MidiPlayerJS/issues/25