### PR TITLE
Fix lag on large midis

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -192,6 +192,7 @@ class Player {
 	 * @return {undefined}
 	 */
 	playLoop(dryRun) {
+		var hadEvent = false;
 		if (!this.inLoop) {
 			this.inLoop = true;
 			this.tick = this.getCurrentTick();
@@ -204,6 +205,8 @@ class Player {
 					this.stop();
 				} else {
 					let event = track.handleEvent(this.tick, dryRun);
+					
+					if (event) hadEvent = true;
 
 					if (dryRun && event) {
 						if (event.hasOwnProperty('name') && event.name === 'Set Tempo') {
@@ -236,6 +239,7 @@ class Player {
 			if (!dryRun) this.triggerPlayerEvent('playing', {tick: this.tick});
 			this.inLoop = false;
 		}
+		return hadEvent;
 	}
 
 	/**
@@ -269,7 +273,9 @@ class Player {
 
 		// Start play loop
 		//window.requestAnimationFrame(this.playLoop.bind(this));
-		this.setIntervalId = setInterval(this.playLoop.bind(this), this.sampleRate);
+		this.setIntervalId = setInterval(() => {
+			while (this.playLoop()) {}
+		}, this.sampleRate);
 		//this.setIntervalId = this.loop();
 		return this;
 	}


### PR DESCRIPTION
This provides a fix for https://github.com/grimmdude/MidiPlayerJS/issues/25 where only one event per track could play each playLoop interval. This means that if there are multiple simultaneous events, they won't play all at the same time, which can be seen when playing black midis. This fix works by doing playLoops until there are no more events to play. This might not be the most efficient way to solve the issue, because it now needs to do a playLoop twice every time there's an event, but it's better than setting sampleRate to 0 which just makes the issue require more events to see.