### PR TITLE
Tweak getCurrentTick() so correct tick is returned when using skipToTick() prior to playing.

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -476,13 +476,7 @@ class Player {
 	 * @return {number}
 	 */
 	getCurrentTick() {
-		if(!this.startTime && this.tick) {
-			return this.startTick;
-
-		} else if(!this.startTime){
-			return 0;
-		}
-
+		if(!this.startTime) return this.startTick;
 		return Math.round(((new Date()).getTime() - this.startTime) / 1000 * (this.division * (this.tempo / 60))) + this.startTick;
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -115,6 +115,16 @@ describe('MidiPlayerJS', function() {
 			})
 		});
 
+		describe('#getCurrentTick', function () {
+			it('should return correct tick when skipping without playing.', function () {
+				const skipTicks = 500;
+				const Player = new MidiPlayer.Player();
+				Player.loadDataUri(zelda);
+				Player.skipToTick(skipTicks);
+				assert.equal(Player.getCurrentTick(), skipTicks);
+			})
+		});
+
 		describe('#getSongTimeRemaining', function () {
 			let Player;
 			beforeEach(function () {


### PR DESCRIPTION
Closes #53 