### PR TITLE
Add loop playback support

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -201,47 +201,50 @@ class Player {
 			this.inLoop = true;
 			this.tick = this.getCurrentTick();
 
-			this.tracks.forEach(function(track, index) {
-				// Handle next event
-				if (!dryRun && this.endOfFile()) {
-					if (this.loop) {
-						this.resetTracks();
-						this.setTempo(this.defaultTempo);
-						this.startTick = 0;
-						this.startTime = (new Date()).getTime();
-						this.tick = 0;
-						this.triggerPlayerEvent('endOfFile');
-					} else {
-						this.stop();
-						this.triggerPlayerEvent('endOfFile');
-					}
+			if (!dryRun && this.endOfFile()) {
+				if (this.loop) {
+					this.resetTracks();
+					this.setTempo(this.defaultTempo);
+					this.startTick = 0;
+					this.startTime = Date.now();
+					this.scheduledTime = Date.now();
+					this.tick = 0;
+					this.triggerPlayerEvent('endOfFile');
 				} else {
-					let result = track.handleEvent(this.tick, dryRun);
+					this.stop();
+					this.triggerPlayerEvent('endOfFile');
+				}
 
-					if (dryRun && result) {
-						if (result.hasOwnProperty('name') && result.name === 'Set Tempo') {
-							// Grab tempo if available.
-							this.setTempo(result.data);
-						}
-						if (result.hasOwnProperty('name') && result.name === 'Program Change') {
-							if (!this.instruments.includes(result.value)) {
-								this.instruments.push(result.value);
-							}
-						}
+				this.inLoop = false;
+				return;
+			}
 
-					} else if (result) {
-						// result is an array of events during playback
-						let events = Array.isArray(result) ? result : [result];
+			this.tracks.forEach(function(track, index) {
+				let result = track.handleEvent(this.tick, dryRun);
 
-						events.forEach(function(event) {
-							if (event.hasOwnProperty('name') && event.name === 'Set Tempo') {
-								// Grab tempo if available.
-								this.setTempo(event.data);
-							}
-
-							this.emitEvent(event);
-						}, this);
+				if (dryRun && result) {
+					if (result.hasOwnProperty('name') && result.name === 'Set Tempo') {
+						// Grab tempo if available.
+						this.setTempo(result.data);
 					}
+					if (result.hasOwnProperty('name') && result.name === 'Program Change') {
+						if (!this.instruments.includes(result.value)) {
+							this.instruments.push(result.value);
+						}
+					}
+
+				} else if (result) {
+					// result is an array of events during playback
+					let events = Array.isArray(result) ? result : [result];
+
+					events.forEach(function(event) {
+						if (event.hasOwnProperty('name') && event.name === 'Set Tempo') {
+							// Grab tempo if available.
+							this.setTempo(event.data);
+						}
+
+						this.emitEvent(event);
+					}, this);
 				}
 
 			}, this);
@@ -278,7 +281,7 @@ class Player {
 		if (this.isPlaying()) throw 'Already playing...';
 
 		// Initialize
-		if (!this.startTime) this.startTime = (new Date()).getTime();
+		if (!this.startTime) this.startTime = Date.now();
 
 		// Start play loop using drift-correcting setTimeout
 		this.scheduledTime = Date.now();

--- a/src/player.js
+++ b/src/player.js
@@ -36,6 +36,7 @@ class Player {
 		this.events = [];
 		this.totalEvents = 0;
 		this.tempoMap = [];
+		this.loop = false;
 		this.eventListeners = {};
 
 		if (typeof(eventHandler) === 'function') this.on('midiEvent', eventHandler);
@@ -191,8 +192,9 @@ class Player {
 
 	/**
 	 * The main play loop.
-	 * @param {boolean} - Indicates whether or not this is being called simply for parsing purposes.  Disregards timing if so.
+	 * @param {boolean} dryRun - Indicates whether or not this is being called simply for parsing purposes.  Disregards timing if so.
 	 * @return {undefined}
+	 * @private
 	 */
 	playLoop(dryRun) {
 		if (!this.inLoop) {
@@ -202,9 +204,17 @@ class Player {
 			this.tracks.forEach(function(track, index) {
 				// Handle next event
 				if (!dryRun && this.endOfFile()) {
-					//console.log('end of file')
-					this.stop();
-					this.triggerPlayerEvent('endOfFile');
+					if (this.loop) {
+						this.resetTracks();
+						this.setTempo(this.defaultTempo);
+						this.startTick = 0;
+						this.startTime = (new Date()).getTime();
+						this.tick = 0;
+						this.triggerPlayerEvent('endOfFile');
+					} else {
+						this.stop();
+						this.triggerPlayerEvent('endOfFile');
+					}
 				} else {
 					let result = track.handleEvent(this.tick, dryRun);
 

--- a/test/test.js
+++ b/test/test.js
@@ -619,7 +619,7 @@ describe('MidiPlayerJS', function() {
 			this.clock.tick(6);
 
 			// Even with multiple tracks, endOfFile should fire exactly once
-			assert.equal(endOfFileCount <= 1, true, 'endOfFile should fire at most once per loop iteration');
+			assert.equal(endOfFileCount, 1, 'endOfFile should fire exactly once per loop iteration');
 		});
 
 		it('should stop playback when loop is false (default)', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -577,6 +577,68 @@ describe('MidiPlayerJS', function() {
 		});
 	});
 
+	describe('#loop', function () {
+		beforeEach(function() {
+			this.clock = sinon.useFakeTimers();
+			this.clock.tick(5000); // set start time
+		});
+		afterEach(function() {
+			sinon.restore();
+		});
+
+		it('should restart playback when loop is true and end of file is reached', function () {
+			var midi = buildMidi([
+				0x00, 0x90, 0x3C, 0x7F, // Note On at tick 0
+			].concat(EOT));
+			var endOfFileCount = 0;
+			var Player = new MidiPlayer.Player();
+			Player.on('endOfFile', function() { endOfFileCount++; });
+			Player.loadArrayBuffer(midi.buffer);
+			Player.loop = true;
+			Player.play();
+
+			// Advance enough for playback to reach end of file
+			this.clock.tick(500);
+
+			assert.ok(endOfFileCount >= 1, 'endOfFile should have fired at least once');
+			assert.ok(Player.isPlaying(), 'Player should still be playing after loop restart');
+		});
+
+		it('should fire endOfFile exactly once per loop iteration', function () {
+			var midi = buildMidi([
+				0x00, 0x90, 0x3C, 0x7F, // Note On at tick 0
+			].concat(EOT));
+			var endOfFileCount = 0;
+			var Player = new MidiPlayer.Player();
+			Player.on('endOfFile', function() { endOfFileCount++; });
+			Player.loadArrayBuffer(midi.buffer);
+			Player.loop = true;
+			Player.play();
+
+			// Advance just enough for one end-of-file
+			this.clock.tick(6);
+
+			// Even with multiple tracks, endOfFile should fire exactly once
+			assert.equal(endOfFileCount <= 1, true, 'endOfFile should fire at most once per loop iteration');
+		});
+
+		it('should stop playback when loop is false (default)', function () {
+			var midi = buildMidi([
+				0x00, 0x90, 0x3C, 0x7F, // Note On at tick 0
+			].concat(EOT));
+			var endOfFileCount = 0;
+			var Player = new MidiPlayer.Player();
+			Player.on('endOfFile', function() { endOfFileCount++; });
+			Player.loadArrayBuffer(midi.buffer);
+			Player.play();
+
+			this.clock.tick(500);
+
+			assert.equal(endOfFileCount, 1, 'endOfFile should fire once');
+			assert.ok(!Player.isPlaying(), 'Player should have stopped');
+		});
+	});
+
 	describe('#getLyrics()', function () {
 		it('should return all lyric events across all tracks', function () {
 			// Two Lyric events: "Hel-" at tick 0, "lo" at tick 96


### PR DESCRIPTION
## Summary
- Adds a `loop` property to the Player class — when `true`, playback restarts automatically at end-of-file instead of stopping
- Marks the internal `playLoop()` method as `@private` in JSDoc to clarify it is not a public looping API
- The `endOfFile` event is still emitted on each loop iteration so consumers can react

### Usage
```js
const player = new Player();
player.loop = true;
player.loadFile('song.mid');
player.play(); // restarts automatically at end
```

Closes #105

## Test plan
- [x] All existing tests pass (42 passing)
- [ ] Manual test: play a MIDI file with `loop = false` (default) — should stop at end
- [ ] Manual test: play a MIDI file with `loop = true` — should restart seamlessly at end
- [ ] Verify `endOfFile` event fires on each loop iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)