### PR TITLE
Fix events at final tick not firing during playback

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -201,24 +201,6 @@ class Player {
 			this.inLoop = true;
 			this.tick = this.getCurrentTick();
 
-			if (!dryRun && this.endOfFile()) {
-				if (this.loop) {
-					this.resetTracks();
-					this.setTempo(this.defaultTempo);
-					this.startTick = 0;
-					this.startTime = Date.now();
-					this.scheduledTime = Date.now();
-					this.tick = 0;
-					this.triggerPlayerEvent('endOfFile');
-				} else {
-					this.stop();
-					this.triggerPlayerEvent('endOfFile');
-				}
-
-				this.inLoop = false;
-				return;
-			}
-
 			this.tracks.forEach(function(track, index) {
 				let result = track.handleEvent(this.tick, dryRun);
 
@@ -248,6 +230,24 @@ class Player {
 				}
 
 			}, this);
+
+			if (!dryRun && this.endOfFile()) {
+				if (this.loop) {
+					this.resetTracks();
+					this.setTempo(this.defaultTempo);
+					this.startTick = 0;
+					this.startTime = Date.now();
+					this.scheduledTime = Date.now();
+					this.tick = 0;
+					this.triggerPlayerEvent('endOfFile');
+				} else {
+					this.stop();
+					this.triggerPlayerEvent('endOfFile');
+				}
+
+				this.inLoop = false;
+				return;
+			}
 
 			if (!dryRun && this.isPlaying()) this.triggerPlayerEvent('playing', {tick: this.tick});
 			this.inLoop = false;

--- a/test/test.js
+++ b/test/test.js
@@ -577,6 +577,39 @@ describe('MidiPlayerJS', function() {
 		});
 	});
 
+	describe('#final tick events', function () {
+		beforeEach(function() {
+			this.clock = sinon.useFakeTimers();
+			this.clock.tick(5000); // set start time
+		});
+		afterEach(function() {
+			sinon.restore();
+		});
+
+		it('should emit events at the final tick before endOfFile fires', function () {
+			// Note On C4 at tick 0, Note Off C4 at tick 96 (= totalTicks), then End of Track
+			var midi = buildMidi([
+				0x00, 0x90, 0x3C, 0x7F, // Note On C4 vel 127 at tick 0
+				0x60, 0x80, 0x3C, 0x00, // Note Off C4 at tick 96
+			].concat(EOT));
+			var events = [];
+			var endOfFileCount = 0;
+			var Player = new MidiPlayer.Player();
+			Player.on('midiEvent', function(event) { events.push(event); });
+			Player.on('endOfFile', function() { endOfFileCount++; });
+			Player.loadArrayBuffer(midi.buffer);
+			Player.play();
+
+			// Advance well past the song length
+			this.clock.tick(2000);
+
+			var noteOffEvents = events.filter(function(e) { return e.name === 'Note off'; });
+			assert.ok(noteOffEvents.length > 0, 'Note off at final tick should have been emitted');
+			assert.equal(noteOffEvents[0].tick, 96, 'Note off should be at the final tick');
+			assert.equal(endOfFileCount, 1, 'endOfFile should have fired');
+		});
+	});
+
 	describe('#loop', function () {
 		beforeEach(function() {
 			this.clock = sinon.useFakeTimers();


### PR DESCRIPTION
## Summary
- Fixes a bug where MIDI events at the final tick (e.g. Note off, End of Track) were never emitted during playback
- The `endOfFile()` check in `playLoop()` was evaluated **before** track events were processed, so when `getCurrentTick()` reached `totalTicks`, the method returned early without emitting any events at that tick
- Moved the `endOfFile()` check to **after** the track event loop so all events fire before the player stops or loops

Closes #98

## Test plan
- [x] All 45 existing tests pass
- [ ] Load a short MIDI file and verify that the final Note off events fire before endOfFile
- [ ] Verify loop playback still resets correctly after emitting final-tick events

🤖 Generated with [Claude Code](https://claude.com/claude-code)